### PR TITLE
Update FixOldTypo.php - remove extra 'Hello world'

### DIFF
--- a/backend/hook/verifications/FixOldTypo.php
+++ b/backend/hook/verifications/FixOldTypo.php
@@ -8,6 +8,6 @@ class FixOldTypo extends FixTypo
         $commits = $this->ensureCommitsCount(2);
         $this->verifyTypoIsFixed($commits[1]);
         $fileContent = implode(' ', $this->getFileContent($commits[0], 'file.txt'));
-        $this->ensure($fileContent == 'Hello world Hello world is an excellent program.', "You haven't resolved the conflict correctly.");
+        $this->ensure($fileContent == 'Hello world is an excellent program.', "You haven't resolved the conflict correctly.");
     }
 }


### PR DESCRIPTION
This whole framework is amazing; however, this particular verification seemed to be mildly confusing ending up with two 'Hello world' values as the correct string. I think the more natural fix is to just expect it once, right?