### PR TITLE
Add Tagging Verification Feature to verifications Branch

### DIFF
--- a/backend/hook/AbstractVerification.php
+++ b/backend/hook/AbstractVerification.php
@@ -52,6 +52,13 @@ abstract class AbstractVerification
         return $count == 1 ? $files[0] : $files;
     }
 
+    protected function ensureTagsCount($commitId, $count)
+    {
+        $tags = $this->getTags($commitId);
+        $this->ensure(count($tags) == $count, "Expected number of tags: %d in commit %s. Received %d.", [$count, substr($commitId, 0, 7), count($tags)]);
+        return $count == 1 ? $tags[0] : $tags;
+    }
+
     public function getCommitterName($commitId = null)
     {
         return GitUtils::getCommitterName($commitId ? $commitId : $this->newRev);
@@ -60,6 +67,11 @@ abstract class AbstractVerification
     protected function getCommits()
     {
         return GitUtils::getCommitIdsBetween($this->oldRev, $this->newRev);
+    }
+
+    protected function getTags($commitId)
+    {
+        return GitUtils::getCommitTagNames($commitId);
     }
 
     protected function getFilenames($commitId)

--- a/backend/hook/exercise-order.txt
+++ b/backend/hook/exercise-order.txt
@@ -11,6 +11,7 @@ case-sensitive-filename
 fix-typo
 forge-date
 fix-old-typo
+tag-it
 commit-lost
 split-commit
 too-many-commits

--- a/backend/hook/hints/TagIt-hint.md
+++ b/backend/hook/hints/TagIt-hint.md
@@ -1,0 +1,1 @@
+Use the [`git tag`](https://git-scm.com/docs/git-tag) command to create a tag for a specific commit and mark important points in your project’s history.

--- a/backend/hook/hints/TagIt-solution.txt
+++ b/backend/hook/hints/TagIt-solution.txt
@@ -1,0 +1,2 @@
+git commit -am "New release"
+git tag v0.2.0

--- a/backend/hook/hints/TagIt-summary.md
+++ b/backend/hook/hints/TagIt-summary.md
@@ -1,0 +1,1 @@
+Tags are references used to label specific points in Git history, such as version releases or significant updates with the [`git tag`](https://git-scm.com/docs/git-tag) command.

--- a/backend/hook/utils/GitUtils.php
+++ b/backend/hook/utils/GitUtils.php
@@ -70,6 +70,16 @@ class GitUtils
         return $commits;
     }
 
+    /** Get all tag names that point to $commitId.
+     * @param $commitId
+     * @return array
+     */
+    public static function getCommitTagNames($commitId)
+    {
+        exec("git tag --points-at $commitId", $tags);
+        return $tags;
+    }
+
     /**
      * Check if given filename would be ignored in the specified commit id by any of the commited .gitignore files.
      * @param $commitId

--- a/backend/hook/verifications/TagIt.php
+++ b/backend/hook/verifications/TagIt.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace GitExercises\hook\verifications;
+
+use GitExercises\hook\AbstractVerification;
+use GitExercises\hook\utils\ConsoleUtils;
+
+class TagIt extends AbstractVerification
+{
+    private const FILE_NAME = "App/src/Program.cs";
+    private const TAGS = ["v0.1.0", "v0.2.0"];
+
+    protected function doVerify()
+    {
+        $commits = $this->ensureCommitsCount(2);
+        $this->ensureFilesCount($commits[1], 1);
+        $this->ensureFilesCount($commits[0], 1);
+        $file1 = $this->getFilenames($commits[1]);
+        $file2 = $this->getFilenames($commits[0]);
+        $this->ensure(in_array(self::FILE_NAME, $file1), "Expected file: %s in commit %s. Received %s.", [ConsoleUtils::blue(self::FILE_NAME), substr($commits[1], 0, 7), ConsoleUtils::red($file1[0])]);
+        $this->ensure(in_array(self::FILE_NAME, $file2), "Expected file: %s in commit %s. Received %s.", [ConsoleUtils::blue(self::FILE_NAME), substr($commits[0], 0, 7), ConsoleUtils::red($file2[0])]);
+        $tag1 = $this->ensureTagsCount($commits[1], 1);
+        $tag2 = $this->ensureTagsCount($commits[0], 1);
+        $this->ensure($tag1 == self::TAGS[0], "Expected tag: %s in commit %s. Received %s.", [ConsoleUtils::blue(self::TAGS[0]), substr($commits[1], 0, 7), ConsoleUtils::red($tag1)]);
+        $this->ensure($tag2 == self::TAGS[1], "Expected tag: %s in commit %s. Received %s.", [ConsoleUtils::blue(self::TAGS[1]), substr($commits[0], 0, 7), ConsoleUtils::red($tag2)]);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to the `verifications` branch that adds tagging verification functionality for 
the `tag-it` exercise. The feature includes the following changes:

#### New Exercise `tag-it`

-  A new exercise, `tag-it`, has been added to the repository. This exercise is designed to help users practice creating and verifying Git tags. See #67

- The exercise requires users to create two commits and associate them with specific tags (`v0.1.0` and `v0.2.0`).

#### Verification Logic

- The exercise verification logic has been implemented in the [TagIt.php](https://github.com/NabilMx99/git-exercises/blob/verifications/backend/hook/verifications/TagIt.php) file.

- The verification ensures:
     - Two commits are present in the branch.
     - The correct file `App/src/Program.cs` is modified in both commits.
     - Each commit has exactly one tag associated with it.
     - The tags `v0.1.0` & `v0.2.0` are correctly associated with the respective commits.

#### Updates to `start.sh` script

- The `start.sh` script initializes the exercise environment by creating the first commit and tag `v0.1.0` and setting up the environment for the user to create the second commit and tag `v0.2.0`. See #67

#### Other changes

- Minor update to the `git verify` alias command to support tag pushes for exercise verification. See #66

https://github.com/user-attachments/assets/039e8abb-36c5-43aa-b0c7-d23f491c1d5a

## ⚠️ Tagging Verification Issue
While testing the `tag-it` exercise, I encountered an issue where the `git verify` command fails with the following error:

https://github.com/user-attachments/assets/11e10502-d9e5-41f8-bfab-25ab81450cc1

<img width="1006" height="337" alt="screenshot" src="https://github.com/user-attachments/assets/9176173c-45da-470e-b11f-727c2d610afa" />

After thorough investigation, I identified that the **root cause of this issue** is that the `tag-it` **branch exists in my fork** but **does not exist in the original repository**. The **server-side hook** in the original repository **validates the branch name against a predefined list of valid exercises**. Since the `tag-it` branch is not present in the original repository, the **hook rejects the push** and **does not process the tags**. 

**I kindly request that you review this pull request, create a branch named `tag-it`, and merge the changes into it**. This will allow the exercise to be recognized as a valid exercise by the server-side hook, resolving the verification issue.
