### PR TITLE
New Exercise: tag-it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# git-exercises
+## Tag It
+
+You are developing an application and **initially released it as version** `0.1.0`. After adding new functionality, you decided to **release a new version**.
+
+The goal of this exercise is to **commit the new functionality** and **tag it** as `v0.2.0`, marking a new release of the application.
+
+> Tip: Ensure the tag name is exactly `v0.2.0`; otherwise, the exercise will be marked as failed.

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,42 @@
 #!/usr/bin/env bash
 
+mkdir -p App/src
+
+echo 'using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello World!");
+        Console.WriteLine("v0.1.0");
+    }
+}' > App/src/Program.cs
+
+git add App/src/Program.cs
+git commit -m "Initial release"
+
+version1=v0.1.0
+version2=v0.2.0
+
+if git rev-parse "$version1" >/dev/null 2>&1; then
+   git update-ref -d "refs/tags/$version1"
+fi
+
+if git rev-parse "$version2" >/dev/null 2>&1; then
+   git update-ref -d "refs/tags/$version2"
+fi
+
+git tag "$version1"
+
+echo 'using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello World!");
+        Console.WriteLine("Added a new functionality!");
+        Console.WriteLine("v0.2.0");
+    }
+}' > App/src/Program.cs


### PR DESCRIPTION
This pull request introduces an exercise focused on tagging releases in a git workflow. It adds a new exercise description to the `README.md` and a setup script (`start.sh`) that demonstrates how to commit new functionality and tag releases. The main changes are grouped below:

#### Exercise documentation:

- Added a new section to `README.md` describing the goal of committing new functionality and tagging the release as `v0.2.0`.

#### Exercise setup and automation:

- Created a new `start.sh` script that initializes the application, commits the initial version, and demonstrates updating the code and tagging both `v0.1.0` and `v0.2.0` releases.
- The script also ensures that any pre-existing tags for `v0.1.0` and `v0.2.0` are removed before creating new ones, to avoid conflicts during the exercise.
- The application code in `App/src/Program.cs` is updated to reflect the new functionality and version for the `v0.2.0` release.